### PR TITLE
RFC: version GA to run on merged PRs only

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.21
+current_version = 1.4.22
 commit = False
 tag = False
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   bump_version:
+    if: github.event.pull_request.merged == true
     runs-on: [self-hosted]
     container:
       image: python:3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.22] - 2023-04-05
+
+### Fixed
+
+- Release GitHub Action now runs only on merged pull requests
+
 ## [1.4.21] - 2023-04-05
 
 ### Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade `mypy` to 1.1.1,
 - Use poetry 1.3.2.
--
 
 ## [1.4.20] - 2023-04-05
 


### PR DESCRIPTION
Update the `version.yml` github action to run only on **merged** closed Pull Requests instead of all Pull Requests.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges