### PR TITLE
RFC: Upgrade checkout action to v3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.22
+current_version = 1.4.23
 commit = False
 tag = False
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           apt update
           apt install -qy libkrb5-dev libsasl2-dev
           pip install poetry==1.3.2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install packages and extras
         run: poetry install --extras "forecast gsheets gdrive" --with dev
       - name: Test base imports
@@ -43,7 +43,7 @@ jobs:
           apt update
           apt install -y libkrb5-dev libsasl2-dev
           pip install poetry==1.3.2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install package
         run: poetry install -vvv --with dev -E "gdrive gsheets forecast"
       - name: Run nox
@@ -59,7 +59,7 @@ jobs:
           apt update
           apt install -y libkrb5-dev libsasl2-dev
           pip install poetry==1.3.2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install package
         run: poetry install -vvv --with dev
       - name: Run interrogate
@@ -75,7 +75,7 @@ jobs:
           apt update
           apt install -y libkrb5-dev libsasl2-dev
           pip install poetry==1.3.2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install package
         run: poetry install -vvv --with dev
       - name: Run nox
@@ -91,7 +91,7 @@ jobs:
           apt update
           apt install -y libkrb5-dev libsasl2-dev
           pip install poetry==1.3.2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install package
         run: poetry install -vvv --with dev
       - name: Run mypy and check lines

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
           apt update
           apt install -y libkrb5-dev libsasl2-dev
           pip install poetry==1.3.2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: pip install packaging
       - name: Fetch source ref
@@ -40,7 +40,7 @@ jobs:
           apt update
           apt install -y libkrb5-dev libsasl2-dev
           pip install poetry==1.3.2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Fetch source ref
         run: git fetch origin $GITHUB_HEAD_REF
       - name: Fetch target ref

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,7 +17,7 @@ jobs:
           apt update
           apt install -y libkrb5-dev libsasl2-dev
           pip install poetry==1.3.2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set tag output
         id: set-tag
         run: echo "::set-output name=tag_name::v$(grep current_version .bumpversion.cfg | cut -d= -f2 | xargs)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.23] - 2023-09-29
+
+### Changed
+
+- Github action checkout upgraded to v3 due to deprecation warnings.
+
 ## [1.4.22] - 2023-04-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "muttlib"
-version = "1.4.21"
+version = "1.4.23"
 description = "Collection of helper modules by Mutt Data."
 readme = "README.md"
 authors = [ "Mutt Data <info@muttdata.ai>",]


### PR DESCRIPTION
Upgrading checkout github action due to deprecation messages.

[related issue](https://github.com/actions/checkout/issues/1047)